### PR TITLE
fix: export LiquidGlassView correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./lib/typescript/src/index.d.ts",
   "exports": {
     ".": {
-      "source": "./src/index.ios.tsx",
+      "source": "./src/index.tsx",
       "types": "./lib/typescript/src/index.d.ts",
       "default": "./lib/module/index.js"
     },

--- a/src/LiquidGlassView.ios.tsx
+++ b/src/LiquidGlassView.ios.tsx
@@ -1,0 +1,1 @@
+export { default as LiquidGlassView } from './LiquidGlassViewNativeComponent';

--- a/src/LiquidGlassView.tsx
+++ b/src/LiquidGlassView.tsx
@@ -1,0 +1,4 @@
+import type { NativeProps } from './LiquidGlassViewNativeComponent';
+import { View } from 'react-native';
+
+export const LiquidGlassView: React.ComponentType<NativeProps> = View;

--- a/src/index.ios.tsx
+++ b/src/index.ios.tsx
@@ -1,2 +1,0 @@
-export { default as LiquidGlassView } from './LiquidGlassViewNativeComponent';
-export { type NativeProps as LiquidGlassViewProps } from './LiquidGlassViewNativeComponent';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,2 @@
-import type { NativeProps } from './LiquidGlassViewNativeComponent';
-import { View } from 'react-native';
-
-export const LiquidGlassView = View as React.ComponentType<NativeProps>;
+export { LiquidGlassView } from './LiquidGlassView';
 export { type NativeProps as LiquidGlassViewProps } from './LiquidGlassViewNativeComponent';


### PR DESCRIPTION
### Summary

The `index` file cannot use platform-specific extensions as `package#exports` won't consider them. So this change adds a separate file with platform specific extension which is re-exported by `index.tsx`