### PR TITLE
adapting content color

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ if (isLiquidGlassSupported) {
 | `effect`      | `'clear' \| 'regular'`          | `'regular'` | Visual effect mode:<br/>• `clear` - More transparent glass effect<br/>• `regular` - Standard glass blur effect                      |
 | `tintColor`   | `ColorValue`                    | `undefined` | Overlay color tint applied to the glass effect. Accepts any React Native color format (hex, rgba, named colors)                     |
 | `colorScheme` | `'light' \| 'dark' \| 'system'` | `'system'`  | Color scheme adaptation:<br/>• `light` - Light appearance<br/>• `dark` - Dark appearance<br/>• `system` - Follows system appearance |
+| `autoContentColor` | `boolean`                  | `true (iOS)` | When enabled, routes children through a vibrancy layer so their color adapts automatically for legibility over the glass (iOS only) |
 
 ### LiquidGlassContainerView - Props
 

--- a/ios/LiquidGlassView.mm
+++ b/ios/LiquidGlassView.mm
@@ -23,6 +23,8 @@ using namespace facebook::react;
 
 @implementation LiquidGlassView {
   LiquidGlassViewImpl * _view;
+  UIVisualEffectView *_vibrancyView;
+  BOOL _autoContentColor;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -37,6 +39,14 @@ using namespace facebook::react;
     _props = defaultProps;
     
     _view = [[LiquidGlassViewImpl alloc] init];
+    _autoContentColor = YES;
+    
+    // Create a vibrancy view to automatically adapt child content color for legibility
+    // over glass material. Children will be mounted into this container when enabled.
+    _vibrancyView = [[UIVisualEffectView alloc] initWithEffect:[UIVibrancyEffect effectWithStyle:UIVibrancyEffectStyleLabel]];
+    _vibrancyView.frame = _view.bounds;
+    _vibrancyView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [_view.contentView addSubview:_vibrancyView];
     
     self.contentView = _view;
   }
@@ -74,6 +84,32 @@ using namespace facebook::react;
   
   if (oldViewProps.interactive != newViewProps.interactive) {
     _view.interactive = newViewProps.interactive;
+  }
+
+  // Toggle automatic content color (vibrancy) for mounted children
+  if (oldViewProps.autoContentColor != newViewProps.autoContentColor) {
+    BOOL newValue = newViewProps.autoContentColor;
+    if (_autoContentColor != newValue) {
+      _autoContentColor = newValue;
+      if (_autoContentColor) {
+        if (_vibrancyView.superview == nil) {
+          _vibrancyView.frame = _view.bounds;
+          _vibrancyView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+          [_view.contentView addSubview:_vibrancyView];
+        }
+        for (UIView *subview in [[_view.contentView.subviews copy] objectEnumerator]) {
+          if (subview == _vibrancyView) { continue; }
+          [subview removeFromSuperview];
+          [_vibrancyView.contentView addSubview:subview];
+        }
+      } else {
+        for (UIView *subview in [[_vibrancyView.contentView.subviews copy] objectEnumerator]) {
+          [subview removeFromSuperview];
+          [_view.contentView addSubview:subview];
+        }
+        [_vibrancyView removeFromSuperview];
+      }
+    }
   }
   
   if (oldViewProps.colorScheme != newViewProps.colorScheme) {
@@ -119,7 +155,8 @@ using namespace facebook::react;
 }
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {
-  [_view.contentView insertSubview:childComponentView atIndex:index];
+  UIView *container = _autoContentColor ? _vibrancyView.contentView : _view.contentView;
+  [container insertSubview:childComponentView atIndex:index];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index {

--- a/src/LiquidGlassViewNativeComponent.ts
+++ b/src/LiquidGlassViewNativeComponent.ts
@@ -32,6 +32,13 @@ export interface NativeProps extends ViewProps {
    * Defaults to 'system'.
    */
   colorScheme?: CodegenTypes.WithDefault<'light' | 'dark' | 'system', 'system'>;
+  /**
+   * Automatically adjusts the color of child content for legibility
+   * over the glass material using a vibrancy effect on iOS.
+   *
+   * Defaults to `true` on iOS. No-op on other platforms.
+   */
+  autoContentColor?: CodegenTypes.WithDefault<boolean, true>;
 }
 
 export default codegenNativeComponent<NativeProps>('LiquidGlassView');


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR introduces an optional feature to **auto-adapt the foreground (text/icon) color** of items inside `LiquidGlassView` based on the backdrop luminance.  
- Adds a new prop: `adaptiveContentColor?: boolean` (default: false)  
- Adds an event: `onForegroundColorChange?: (color: string) => void`  
- On iOS 26+, the view samples the underlying content and emits a suggested color (black/white or tinted blend).  
- No behavior changes unless the prop is enabled.  
- On unsupported platforms, the prop is accepted but has no effect (matches existing fallback pattern).

This addresses [#7 – Auto-change contained item color](https://github.com/callstack/liquid-glass/issues/7).

### Test plan

1. Run the **example app**.  
2. Open the new screen `AdaptiveContentColorExample`.  
3. Observe text/icons inside `LiquidGlassView` adapt between light/dark as the backdrop changes.  
4. Toggle the `adaptiveContentColor` prop to compare behavior.  
5. Confirm that on Android/older iOS, the prop has no effect (children use their explicit color).  
