### PR TITLE
feat: detect compatibility mode, fix crash on iOS 18.5

### DIFF
--- a/ios/LiquidGlassModule.mm
+++ b/ios/LiquidGlassModule.mm
@@ -8,8 +8,11 @@
 {
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 260000 /* __IPHONE_26_0 */
   if (@available(iOS 26.0, *)) {
+    NSDictionary *infoPlist = [[NSBundle mainBundle] infoDictionary];
+    BOOL requiresDesignCompatibility = infoPlist[@"UIDesignRequiresCompatibility"];
+    
     _constants = facebook::react::typedConstants<JS::NativeLiquidGlassModule::Constants>({
-      .isLiquidGlassSupported = YES
+      .isLiquidGlassSupported = !requiresDesignCompatibility
     });
   }
 #else

--- a/ios/LiquidGlassModule.mm
+++ b/ios/LiquidGlassModule.mm
@@ -14,12 +14,14 @@
     _constants = facebook::react::typedConstants<JS::NativeLiquidGlassModule::Constants>({
       .isLiquidGlassSupported = !requiresDesignCompatibility
     });
+    
+    return;
   }
-#else
+#endif
+  
   _constants = facebook::react::typedConstants<JS::NativeLiquidGlassModule::Constants>({
     .isLiquidGlassSupported = NO
   });
-#endif
 }
 
 - (facebook::react::ModuleConstants<JS::NativeLiquidGlassModule::Constants>)constantsToExport

--- a/src/isLiquidGlassSupported.ios.ts
+++ b/src/isLiquidGlassSupported.ios.ts
@@ -1,0 +1,4 @@
+import NativeLiquidGlassModule from './NativeLiquidGlassModule';
+
+export const isLiquidGlassSupported =
+  NativeLiquidGlassModule.getConstants().isLiquidGlassSupported;

--- a/src/isLiquidGlassSupported.ts
+++ b/src/isLiquidGlassSupported.ts
@@ -1,4 +1,1 @@
-import NativeLiquidGlassModule from './NativeLiquidGlassModule';
-
-export const isLiquidGlassSupported =
-  NativeLiquidGlassModule.getConstants().isLiquidGlassSupported;
+export const isLiquidGlassSupported = false;


### PR DESCRIPTION
### Summary

This PR detect compatibility mode and return this information accordingly in `isLiquidGlassSupported`

It also fixes crash on iOS 18.5 when building with Xcode 26