### PR TITLE
fix: move off update mask for setting up view

### DIFF
--- a/ios/LiquidGlassView.mm
+++ b/ios/LiquidGlassView.mm
@@ -55,7 +55,7 @@ using namespace facebook::react;
 {
   const auto &oldViewProps = *std::static_pointer_cast<LiquidGlassViewProps const>(_props);
   const auto &newViewProps = *std::static_pointer_cast<LiquidGlassViewProps const>(props);
-  
+
   if (oldViewProps.tintColor != newViewProps.tintColor) {
     _view.effectTintColor = RCTUIColorFromSharedColor(newViewProps.tintColor);
   }
@@ -101,16 +101,7 @@ using namespace facebook::react;
     _view.layer.cornerCurve = self.layer.cornerCurve;
   }
   
-  
   [super updateProps:props oldProps:oldProps];
-}
-
-- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask {
-  [super finalizeUpdates:updateMask];
-  
-  if (updateMask == RNComponentViewUpdateMaskProps) {
-    [_view setupView];
-  }
 }
 
 - (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics

--- a/ios/LiquidGlassView.swift
+++ b/ios/LiquidGlassView.swift
@@ -26,9 +26,15 @@ import UIKit
 @available(iOS 26.0, *)
 @objc public class LiquidGlassViewImpl: UIVisualEffectView {
   private var isFirstMount: Bool = true
-  @objc public var effectTintColor: UIColor?
-  @objc public var interactive: Bool = false
-  @objc public var style: LiquidGlassEffect = .regular
+  @objc public var effectTintColor: UIColor? {
+    didSet { self.setupView() }
+  }
+  @objc public var interactive: Bool = false {
+    didSet { self.setupView() }
+  }
+  @objc public var style: LiquidGlassEffect = .regular {
+    didSet { self.setupView() }
+  }
 
   public override func layoutSubviews() {
     if (self.effect != nil) { return }


### PR DESCRIPTION
### Summary

This PR fixes weird behavior of the glass view when placing it inside of Context.. Turns out finalize updates method is called differently when placed in context