### PR TITLE
fix: move version check to runtime

### DIFF
--- a/ios/LiquidGlassView.swift
+++ b/ios/LiquidGlassView.swift
@@ -40,8 +40,11 @@ import UIKit
   }
 
 
-  @available(iOS 26.0, *)
   @objc public func setupView() {
+    guard #available(iOS 26.0, *) else {
+      return
+    }
+
     guard let preferredStyle = style.converted else {
       UIView.animate {
         // TODO: Looks like only assigning nil is not working, check this after stable iOS 26 is rolled out.


### PR DESCRIPTION
### Summary

This PR moves version check to runtime instead of just annotating it.



https://github.com/user-attachments/assets/c0030dc1-8047-4bd7-b804-9306f86a06b4


Fixes: #23 