### PR TITLE
fix: add runtime check for UIGlassEffect availability on iOS 26 betas

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -10,6 +10,7 @@ gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '< 1.3.4'
 
 # Ruby 3.4.0 has removed some libraries from the standard library.
+gem 'nkf'
 gem 'bigdecimal'
 gem 'logger'
 gem 'benchmark'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,0 +1,122 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.8)
+    activesupport (7.2.3)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
+    algoliasearch (1.27.5)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
+    atomos (0.1.3)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (3.3.1)
+    claide (1.1.0)
+    cocoapods (1.15.2)
+      addressable (~> 2.8)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.15.2)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (>= 2.3.0, < 3.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.8.0)
+      nap (~> 1.0)
+      ruby-macho (>= 2.3.0, < 3.0)
+      xcodeproj (>= 1.23.0, < 2.0)
+    cocoapods-core (1.15.2)
+      activesupport (>= 5.0, < 8)
+      addressable (~> 2.8)
+      algoliasearch (~> 1.0)
+      concurrent-ruby (~> 1.1)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+      netrc (~> 0.11)
+      public_suffix (~> 4.0)
+      typhoeus (~> 1.0)
+    cocoapods-deintegrate (1.0.5)
+    cocoapods-downloader (2.1)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.1)
+    cocoapods-trunk (1.6.0)
+      nap (>= 0.8, < 2.0)
+      netrc (~> 0.11)
+    cocoapods-try (1.2.0)
+    colored2 (3.1.2)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.5.5)
+    drb (2.2.3)
+    escape (0.0.4)
+    ethon (0.15.0)
+      ffi (>= 1.15.0)
+    ffi (1.17.2)
+    fourflusher (2.3.1)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.1.3)
+    httpclient (2.9.0)
+      mutex_m
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    json (2.16.0)
+    logger (1.7.0)
+    minitest (5.26.2)
+    molinillo (0.8.0)
+    mutex_m (0.3.0)
+    nanaimo (0.3.0)
+    nap (1.1.0)
+    netrc (0.11.0)
+    nkf (0.2.0)
+    public_suffix (4.0.7)
+    rexml (3.4.4)
+    ruby-macho (2.5.1)
+    securerandom (0.4.1)
+    typhoeus (1.5.0)
+      ethon (>= 0.9.0, < 0.16.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    xcodeproj (1.25.1)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.3.0)
+      rexml (>= 3.3.6, < 4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (>= 6.1.7.5, != 7.1.0)
+  benchmark
+  bigdecimal
+  cocoapods (>= 1.13, != 1.15.1, != 1.15.0)
+  concurrent-ruby (< 1.3.4)
+  logger
+  mutex_m
+  nkf
+  xcodeproj (< 1.26.0)
+
+RUBY VERSION
+   ruby 3.4.6p54
+
+BUNDLED WITH
+   2.7.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.4):
     - hermes-engine/Pre-built (= 0.81.4)
   - hermes-engine/Pre-built (0.81.4)
-  - LiquidGlass (0.5.0):
+  - LiquidGlass (0.6.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2065,74 +2065,74 @@ SPEC CHECKSUMS:
   DGSwiftUtilities: 567f8d5ee618f0b7afb185b17aa45ff356315a0f
   FBLazyVector: 9e0cd874afd81d9a4d36679daca991b58b260d42
   hermes-engine: 35c763d57c9832d0eef764316ca1c4d043581394
-  LiquidGlass: 05f6d68f6310d1bf128a377e5cdaadc1d9e9a02d
+  LiquidGlass: ba2360d3eb0821228db3d88bee3d30c8792ad32b
   RCTDeprecation: 7487d6dda857ccd4cb3dd6ecfccdc3170e85dcbc
   RCTRequired: 54128b7df8be566881d48c7234724a78cb9b6157
   RCTTypeSafety: d2b07797a79e45d7b19e1cd2f53c79ab419fe217
   React: 2073376f47c71b7e9a0af7535986a77522ce1049
   React-callinvoker: 00fa0972a70df7408a4f088144b67207b157e386
-  React-Core: 7edc3b0763d7a47cf5610b32e0e790ac10dd5410
-  React-Core-prebuilt: ab6d77841d4bb8d247c4358663c6c71836e4f461
-  React-CoreModules: a02474243c3efbdc767b44dc029b452b0476cee1
-  React-cxxreact: b3b6c8c0823ff10237f1c6c1ad067c2577bc2f84
+  React-Core: d375dd308561785c739a621a21802e5e7e047dee
+  React-Core-prebuilt: dde79b89f8863efebb1d532a3335f472927da669
+  React-CoreModules: 3eb9b1410a317987c557afc683cc50099562c91d
+  React-cxxreact: 724210b64158d97f150d8d254a7319e73ef77ee7
   React-debug: c01d176522cf57cdc4a4a66d1974968fcf497f32
-  React-defaultsnativemodule: d8164fe3151fbc98b49580b37bd565da14d9fbfa
-  React-domnativemodule: 848a14d603966ec5b244cbd5e4a4c330ae71abb1
-  React-Fabric: 027d67e708433a3e08e0257dff8f0293afe1b761
-  React-FabricComponents: 378d5c830a42899fb49283d379424f4a6af92265
-  React-FabricImage: a844845a53655c23e05e102f29e5c2a5cdfbaed0
-  React-featureflags: a190badbbda1e72cf7e7accbfbcd2070ab35c431
-  React-featureflagsnativemodule: b0f97eedbbe788c114cf2d0bb5c6b28b55e9b4f9
-  React-graphics: eeef269ea0a459baf20748cbbfc099c6263f6596
-  React-hermes: 3f94c83c8238913c50fdd23e276d64cfc520b08c
-  React-idlecallbacksnativemodule: 7510daba721b4389a2a35fd0a97f5f782bbacbe4
-  React-ImageManager: 13f32b59f5c873df59f05b8102ebc075a1d66c4d
-  React-jserrorhandler: 9a7140314550bec0368898985ca2f0d87cb0744b
-  React-jsi: d987f2b32fdda6c521e750a639ab3b04ab9de44b
-  React-jsiexecutor: 63925b9dc840d26880adc1145dc3ea701a2b06a4
-  React-jsinspector: 7e36f5182f024ee11b7ac60252db9cd3219deefb
-  React-jsinspectorcdp: 7c121234fff135fb6e76534bdbfae1d6e1a05a52
-  React-jsinspectornetwork: c0c040786ea67d3b10aa687460d6b96b51365cc5
-  React-jsinspectortracing: 73f22a1a52a049409326abb93b8d0d2376a2ed37
-  React-jsitooling: f3bb6e50d6d5a1ff581d4ede35722ef760c6b12c
-  React-jsitracing: 008ed6c9a92ba5652a23f86cd853248f7fbb9a22
-  React-logger: 472e292c035c024ac73070cd6cbd011a827136f9
-  React-Mapbuffer: 823a2c0e0d1826c784f808174626d5229f59be17
-  React-microtasksnativemodule: 70cdf4826e52c7bcf98bc55255c3e30b5455d318
-  react-native-ios-context-menu: 4da7429c7b109d09aa059a6210eb64808f84cb9d
-  react-native-ios-utilities: 34ffb7109843010b6ade9e690d35c48080c17ded
-  react-native-safe-area-context: add9b4ba236fe95ec600604d0fc72f395433dd59
-  react-native-slider: b76fa3dd989d25e8c2751c2a546674dfc0c2b6f8
-  React-NativeModulesApple: e653919faff1f76eadf02373bda26c085bf348e3
+  React-defaultsnativemodule: 3953ff49013fa997e72586628e1d218fdaf3abdb
+  React-domnativemodule: 540b9c7a8f31b6f4ed449aafd3a272e1f1107089
+  React-Fabric: 00b792be016edad758a63c4ebac15e01d35f6355
+  React-FabricComponents: 16ebdb9245d91ec27985a038d0a6460f499db54e
+  React-FabricImage: 2a967b5f0293c1c49ec883babfd4992d161e3583
+  React-featureflags: 4150b4ddac8210b1e3c538cfb455050b5ee05d8d
+  React-featureflagsnativemodule: ff977040205b96818ac1f884846493cb8a2aca28
+  React-graphics: ec689ac1c13a9ddb1af83baf195264676ecdbeb6
+  React-hermes: ff60a3407f27f3fc82f661774a7ab6559a24ab69
+  React-idlecallbacksnativemodule: 5f5ce3c424941f77da4ac3adba681149e68b1221
+  React-ImageManager: 8d87296a86f9ee290c1d32c68c7be1be63492467
+  React-jserrorhandler: 072756f12136284c86e96c33cdfece4d7286a99f
+  React-jsi: b507852b42a9125dffbf6ae7a33792fb521b29a2
+  React-jsiexecutor: f970eed6debb91fe5d5d6cb5734d39cf86c59896
+  React-jsinspector: 766e113e9482b22971b30236d10c04d8af38269e
+  React-jsinspectorcdp: 5b60350e29fe2566d9ed9799858c04b8e6095a3e
+  React-jsinspectornetwork: b3cc9a20c6b270f792eaaaa14313019a031b327d
+  React-jsinspectortracing: d99120fcf0864209c45cefbc9fc4605c8189c0ef
+  React-jsitooling: 9e41724cc47feadefbede31ca91d70f6ff079656
+  React-jsitracing: ca020d934502de8e02cccf451501434a5e584027
+  React-logger: 7b234de35acb469ce76d6bbb0457f664d6f32f62
+  React-Mapbuffer: fbe1da882a187e5898bdf125e1cc6e603d27ecae
+  React-microtasksnativemodule: 76905804171d8ccbe69329fc84c57eb7934add7f
+  react-native-ios-context-menu: 9f23509b5722166590c4c53180991319cc44e286
+  react-native-ios-utilities: 14afbb6d64f67dce464df5e4bf09d3e80334adde
+  react-native-safe-area-context: 42a1b4f8774b577d03b53de7326e3d5757fe9513
+  react-native-slider: 8c562583722c396a3682f451f0b6e68e351ec3b9
+  React-NativeModulesApple: a9464983ccc0f66f45e93558671f60fc7536e438
   React-oscompat: 73db7dbc80edef36a9d6ed3c6c4e1724ead4236d
-  React-perflogger: f2116e7a0c1562ed7cbcaa2c90e8fdb0bc28df78
-  React-performancetimeline: 6ea21e31c0ccf56cebe26c7110429fe25314ff22
+  React-perflogger: 123272debf907cc423962adafcf4513320e43757
+  React-performancetimeline: 095146e4dc8fa4568e44d7a9debc134f27e103f9
   React-RCTActionSheet: 9fc2a0901af63cefe09c8df95a08c2cf8bb7797b
-  React-RCTAnimation: 3728b2991c073aa629a90df00997b0c6cec54b8e
-  React-RCTAppDelegate: bd7fa41be1461c97e67f63efbee0d46dcc202a8b
-  React-RCTBlob: 4ac65a15788a793a42e4eb8c2f4325146aa3baed
-  React-RCTFabric: 0f3aca011a1448bc027cf65f485ade90f231a6d9
-  React-RCTFBReactNativeSpec: 4838aece65e8710ce8238aefe54b6bc85314e57a
-  React-RCTImage: 9cc8cff72a6aa2b0a94ad8b0c18b97822825eaee
-  React-RCTLinking: fa8aa5a3ed268e364d65f7025f01f94cd9d700a1
-  React-RCTNetwork: 139283847dd0dfa98f44c843a49e8dedc5fc2d99
-  React-RCTRuntime: 5759c5cb10618ce9b1ae1073d689b908879b76ab
-  React-RCTSettings: f101bafea6c0f73bb6cabec765bb7af60eb79e80
-  React-RCTText: b5a219996342e6727dae7f07e6ddcc5377fc32a2
-  React-RCTVibration: 3a04d19e46e19af9cdfd43b9bb17fa244c633100
+  React-RCTAnimation: 785e743e489bc7aec14415dbc15f4f275b2c0276
+  React-RCTAppDelegate: 0602c9e13130edcde4661ea66d11122a3a66f11a
+  React-RCTBlob: ae53b7508a5ced43378de2a88816f63423df1f24
+  React-RCTFabric: 687a0cfb5726adea7fac63560b04410c86d97134
+  React-RCTFBReactNativeSpec: 7c55cf4fb4d2baad32ce3850b8504a6ee22e11ce
+  React-RCTImage: f45474c75cdf1526114f75b27e86d004aa171b90
+  React-RCTLinking: 56622ff97570e15e01dd9b5a657010c756a9e2d8
+  React-RCTNetwork: 3fffa1ab5d6981f839e7679d56f8cb731ba92c07
+  React-RCTRuntime: f38c04f744596fc8e1b4c5f6a57fc05c26955257
+  React-RCTSettings: f4a8e1bd36f58ec8273c73d3deefdcf90143ac6a
+  React-RCTText: da852a51dd1d169b38136a4f4d1eaed35376556b
+  React-RCTVibration: ff92ef336e32e18efff0fa83c798a2dbbebe09bd
   React-rendererconsistency: b83b300e607f4e30478a5c3365e260a760232b04
-  React-renderercss: 10faf35f1b235ee768d84bca40733418669dd8bb
-  React-rendererdebug: af3c8224c58498efdc0c10c3c376b724f8896668
-  React-RuntimeApple: 119f51db881637ffcc6186c73f6a40840fd3bc0e
-  React-RuntimeCore: 2394c9276eb30c7156e9eb93091693ed6864b9a8
-  React-runtimeexecutor: 3b2bed6b77b4016273d354bcb1d6eb2ad5a457a2
-  React-RuntimeHermes: 3148d449c52f1ff987eebbb72ce2ed7542e31b5f
-  React-runtimescheduler: ef67578dc2c5b27ec32b322591d965cef6e8e8a4
-  React-timing: 37d287f84c57ce9186fbb494dbbdb3a272a3ee19
-  React-utils: 3c6c77bb22ce2e5947daf072d49f361a95fd12c6
-  ReactAppDependencyProvider: b20fba6c3d091a393925890009999472c8f94d95
-  ReactCodegen: c7382a9d84b5826fec1441c7eec6e424499bc8c0
-  ReactCommon: b720ccad5e1e8a528746c39b671825fcb7207d3c
+  React-renderercss: aa6a3cdd4fa4e3726123c42b49ba4dd978f81688
+  React-rendererdebug: 6b12a782caf2e7e2f730434264357b7b6aed1781
+  React-RuntimeApple: 8934aab108dcab957a87208fef4b6f1b3a04973a
+  React-RuntimeCore: 1d4345561ecc402e9e88b38e1d9b059a7a13b113
+  React-runtimeexecutor: a9a059f222e4d78f45a4e92cada48a5fde989fb8
+  React-RuntimeHermes: 05b955709a75038d282a9420342d7bea5857768a
+  React-runtimescheduler: 4ce23c9157b51101092537d4171ea4de48a5b863
+  React-timing: 62441edf291b91ab5b96ab8f2f8fb648c063ce6f
+  React-utils: 485abe7eaefa04b20e0ef442593e022563a1419b
+  ReactAppDependencyProvider: 433ddfb4536948630aadd5bd925aff8a632d2fe3
+  ReactCodegen: a15ad48730e9fb2a51a4c9f61fe1ed253dfcf10f
+  ReactCommon: 149b6c05126f2e99f2ed0d3c63539369546f8cae
   ReactNativeDependencies: ed6d1e64802b150399f04f1d5728ec16b437251e
   Yoga: 051f086b5ccf465ff2ed38a2cf5a558ae01aaaa1
 

--- a/ios/LiquidGlassView.swift
+++ b/ios/LiquidGlassView.swift
@@ -45,6 +45,18 @@ import UIKit
       return
     }
 
+    // Runtime check to ensure UIGlassEffect is available
+    // This handles cases where early iOS 26 beta releases may not have this API
+    guard let glassEffectClass = NSClassFromString("UIGlassEffect") as? NSObject.Type else {
+      return
+    }
+    
+    // Verify that the effectWithStyle: selector is available
+    // This provides an additional safety check for early beta versions
+    guard glassEffectClass.responds(to: Selector(("effectWithStyle:"))) else {
+      return
+    }
+
     guard let preferredStyle = style.converted else {
       UIView.animate {
         // TODO: Looks like only assigning nil is not working, check this after stable iOS 26 is rolled out.
@@ -71,4 +83,3 @@ import UIKit
 @objc public class LiquidGlassViewImpl: UIView {}
 
 #endif
-


### PR DESCRIPTION
## Summary
- Adds runtime check using `NSClassFromString` to verify `UIGlassEffect` availability before use, preventing crashes on early iOS 26 beta releases where the API might be missing

Fixes #28