### PR TITLE
fix(ios): ensure contentView forwards touches after glass effect setup

### DIFF
--- a/ios/LiquidGlassView.swift
+++ b/ios/LiquidGlassView.swift
@@ -75,6 +75,14 @@ import UIKit
       // Animate only the effect is changed after first mount.
       UIView.animate { self.effect = glassEffect }
     }
+
+    // UIGlassEffect can reconfigure the internal contentView in a way that
+    // disables user interaction when no subviews are present at the time the
+    // effect is applied. In React Native (Fabric), child component views may
+    // be mounted into contentView *after* layoutSubviews triggers setupView(),
+    // leaving contentView with userInteractionEnabled == false for the
+    // lifetime of this view. Force it back on so touches always reach children.
+    self.contentView.isUserInteractionEnabled = true
   }
 }
 


### PR DESCRIPTION
## Problem

When `LiquidGlassView` is used in React Native (Fabric renderer) with interactive child components like `Pressable`, touches intermittently fail to reach those children. The bug is **session-level**: either all `LiquidGlassView` instances work for the entire app session, or none of them do. A cold restart may or may not fix it.

## Root Cause

There is a race condition between Fabric's component mount pass and UIKit's layout pass.

`LiquidGlassViewImpl.setupView()` is called from `layoutSubviews()` and applies the `UIGlassEffect` via `self.effect = glassEffect`. When `UIGlassEffect` is applied, UIKit internally reconfigures the `contentView` (`_UIVisualEffectContentView`). If no subviews are present in `contentView` at that moment, the `contentView` can end up with `userInteractionEnabled == false`.

In Fabric, child component views are mounted into `contentView` via `mountChildComponentView:index:` — but this can happen **after** `layoutSubviews` has already triggered `setupView()`. The ordering depends on main thread scheduling and varies per app launch.

Once `setupView()` runs and the `layoutSubviews` guard (`if self.effect != nil { return }`) prevents it from re-running, the `contentView` touch state is locked for the lifetime of that view.

**Timeline — broken session:**
1. `layoutSubviews` → `setupView()` → `self.effect = glassEffect` → `contentView.isUserInteractionEnabled` set to `false` (no subviews yet)
2. Fabric mounts `Pressable` children into `contentView`
3. Children are visible but never receive touches

**Timeline — working session:**
1. Fabric mounts `Pressable` children into `contentView`
2. `layoutSubviews` → `setupView()` → `self.effect = glassEffect` → `contentView` touch handling set up correctly (subviews present)
3. Everything works

## Fix

Explicitly set `self.contentView.isUserInteractionEnabled = true` after every effect application in `setupView()`. This guarantees touches always flow through to child views regardless of mount ordering.

## Environment

- iOS 26 beta (26.1)
- React Native 0.83 (Fabric / New Architecture)
- @callstack/liquid-glass 0.7.0

## Reproduction

```tsx
<LiquidGlassView effect="regular" style={{ borderRadius: 25, padding: 16 }}>
  <Pressable onPress={() => console.log('pressed')}>
    <Text>Tap me</Text>
  </Pressable>
</LiquidGlassView>
```

Cold-restart the app multiple times. On some launches, the `Pressable` will not respond to taps. Once it fails, it stays broken for the entire session. Once it works, it stays working.