### PR TITLE
fix: iOS build on react-native 0.87 (namespaced header imports)

### DIFF
--- a/ios/LiquidGlassContainerView.mm
+++ b/ios/LiquidGlassContainerView.mm
@@ -5,7 +5,7 @@
 #import <react/renderer/components/LiquidGlassViewSpec/Props.h>
 #import <react/renderer/components/LiquidGlassViewSpec/RCTComponentViewHelpers.h>
 
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTFabricComponentsPlugins.h>
 
 #if __has_include("LiquidGlass/LiquidGlass-Swift.h")
 #import "LiquidGlass/LiquidGlass-Swift.h"

--- a/ios/LiquidGlassView.mm
+++ b/ios/LiquidGlassView.mm
@@ -4,10 +4,10 @@
 #import <react/renderer/components/LiquidGlassViewSpec/EventEmitters.h>
 #import <react/renderer/components/LiquidGlassViewSpec/Props.h>
 #import <react/renderer/components/LiquidGlassViewSpec/RCTComponentViewHelpers.h>
-#import "RCTImagePrimitivesConversions.h"
+#import <react/renderer/imagemanager/RCTImagePrimitivesConversions.h>
 
-#import "RCTFabricComponentsPlugins.h"
-#import "RCTConversions.h"
+#import <React/RCTFabricComponentsPlugins.h>
+#import <React/RCTConversions.h>
 
 #if __has_include("LiquidGlass/LiquidGlass-Swift.h")
 #import "LiquidGlass/LiquidGlass-Swift.h"

--- a/ios/LiquidGlassView.mm
+++ b/ios/LiquidGlassView.mm
@@ -4,7 +4,12 @@
 #import <react/renderer/components/LiquidGlassViewSpec/EventEmitters.h>
 #import <react/renderer/components/LiquidGlassViewSpec/Props.h>
 #import <react/renderer/components/LiquidGlassViewSpec/RCTComponentViewHelpers.h>
+#if __has_include(<react/renderer/imagemanager/RCTImagePrimitivesConversions.h>)
+// react-native 0.87+
 #import <react/renderer/imagemanager/RCTImagePrimitivesConversions.h>
+#else
+#import "RCTImagePrimitivesConversions.h"
+#endif
 
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTConversions.h>

--- a/ios/LiquidGlassView.mm
+++ b/ios/LiquidGlassView.mm
@@ -4,12 +4,7 @@
 #import <react/renderer/components/LiquidGlassViewSpec/EventEmitters.h>
 #import <react/renderer/components/LiquidGlassViewSpec/Props.h>
 #import <react/renderer/components/LiquidGlassViewSpec/RCTComponentViewHelpers.h>
-#if __has_include(<react/renderer/imagemanager/RCTImagePrimitivesConversions.h>)
-// react-native 0.87+
 #import <react/renderer/imagemanager/RCTImagePrimitivesConversions.h>
-#else
-#import "RCTImagePrimitivesConversions.h"
-#endif
 
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTConversions.h>


### PR DESCRIPTION
React Native 0.87 removed the legacy bridge, and with it the header search paths that made quoted imports like `#import "RCTFabricComponentsPlugins.h"` resolve. On 0.87 the iOS build fails in `LiquidGlassView.mm` and `LiquidGlassContainerView.mm`.

This switches the three affected imports to their namespaced form:

- `"RCTFabricComponentsPlugins.h"` → `<React/RCTFabricComponentsPlugins.h>` (both files)
- `"RCTConversions.h"` → `<React/RCTConversions.h>`
- `"RCTImagePrimitivesConversions.h"` → `<react/renderer/imagemanager/RCTImagePrimitivesConversions.h>` (where the header lives)

We've been carrying this change as a pnpm patch on 0.8.0 since upgrading our app to react-native 0.87.0. The build passes and the glass views render as before.

All three namespaced paths resolve on the whole supported range, not just 0.87: `React-ImageManager.podspec` has shipped `header_dir "react/renderer/imagemanager"` since at least react-native 0.80, so no version guard is needed. What 0.87 removed was only the search paths that made the quoted form work.

