### PR TITLE
fix(ios): use module-qualified imports for React headers inside xcframework

### DIFF
--- a/ios/LiquidGlassContainerView.mm
+++ b/ios/LiquidGlassContainerView.mm
@@ -5,7 +5,7 @@
 #import <react/renderer/components/LiquidGlassViewSpec/Props.h>
 #import <react/renderer/components/LiquidGlassViewSpec/RCTComponentViewHelpers.h>
 
-#import "RCTFabricComponentsPlugins.h"
+#import <React/RCTFabricComponentsPlugins.h>
 
 #if __has_include("LiquidGlass/LiquidGlass-Swift.h")
 #import "LiquidGlass/LiquidGlass-Swift.h"
@@ -67,4 +67,3 @@ using namespace facebook::react;
 #endif
 
 @end
-

--- a/ios/LiquidGlassView.mm
+++ b/ios/LiquidGlassView.mm
@@ -6,8 +6,8 @@
 #import <react/renderer/components/LiquidGlassViewSpec/RCTComponentViewHelpers.h>
 #import "RCTImagePrimitivesConversions.h"
 
-#import "RCTFabricComponentsPlugins.h"
-#import "RCTConversions.h"
+#import <React/RCTFabricComponentsPlugins.h>
+#import <React/RCTConversions.h>
 
 #if __has_include("LiquidGlass/LiquidGlass-Swift.h")
 #import "LiquidGlass/LiquidGlass-Swift.h"


### PR DESCRIPTION
## Problem

Building with React Native 0.87+ fails with the following error:

```
ios/LiquidGlassView.mm:10:9 'RCTConversions.h' file not found
```

Starting from React Native 0.87, `RCTConversions.h` and `RCTFabricComponentsPlugins.h` are no longer shipped as loose headers under `Headers/Public/`. Instead, they are packaged inside the **prebuilt `React-Core-prebuilt/React.xcframework`**:

```
Pods/React-Core-prebuilt/React.xcframework/ios-arm64/React.framework/Headers/RCTConversions.h
Pods/React-Core-prebuilt/React.xcframework/ios-arm64_x86_64-simulator/React.framework/Headers/RCTConversions.h
```

CocoaPods does **not** automatically append xcframework slice `Headers/` directories to `HEADER_SEARCH_PATHS`, so bare quoted imports (`#import "RCTConversions.h"`) cannot be resolved at compile time.

## Fix

Replace quoted imports with the framework-qualified form:

```objc
// Before
#import "RCTFabricComponentsPlugins.h"
#import "RCTConversions.h"

// After
#import <React/RCTFabricComponentsPlugins.h>
#import <React/RCTConversions.h>
```

Xcode resolves `<React/...>` through the linked xcframework and correctly selects the right architecture slice (device vs. simulator) at build time.

## Files changed

- `ios/LiquidGlassView.mm` — fix `RCTFabricComponentsPlugins.h` and `RCTConversions.h` imports
- `ios/LiquidGlassContainerView.mm` — fix `RCTFabricComponentsPlugins.h` import

## Tested

Verified on React Native 0.87 with CocoaPods 1.16 on both device and simulator targets.